### PR TITLE
Updating share styles to invert colors on hover.

### DIFF
--- a/_sass/_custom.scss
+++ b/_sass/_custom.scss
@@ -384,23 +384,54 @@ i.share-button:hover {
 .fa-facebook-official {
     color: #3b5998;
 }
+.fa-facebook-official:hover {
+    background-color: #3b5998;
+    color:white;
+}
+
 .fa-google-plus {
     color: #d34836;
 }
+.fa-google-plus:hover {
+    background-color: #d34836;
+    color: white;
+}
+
 
 .fa-linkedin {
     color: #0077b5;
 }
+.fa-linkedin:hover {
+    background-color: #0077b5;
+    color: white;
+}
+
 .fa-envelop {
     color: #444444;
 }
+.fa-envelope:hover {
+    background-color: #444444;
+    color: white;
+}
+
+
 .fa-reddit {
     color: #ff5700;
 }
+.fa-reddit:hover {
+    background-color: #ff5700;
+    color: white;
+}
+
 
 .fa-twitter {
     color: #4099FF;
 }
+.fa-twitter:hover {
+    background-color: #4099FF;
+    color: white;
+}
+
 
 .fa-github-alt {
     color: #333;


### PR DESCRIPTION
I found your blog post super helpful [share-buttons-jekyll](https://blog.webjeda.com/share-buttons-jekyll/) about building a custom share buttons. I took your code and modified it for my purposes and ended up with a nice invert share buttons colors on hover. I wanted to share the changes in the styles with you.

My repo is at [https://github.com/ahoefling/ahoefling.github.io](https://github.com/ahoefling/ahoefling.github.io)

You can find the files I built from your blog post at:

- [https://github.com/ahoefling/ahoefling.github.io/blob/master/_includes/share.html](share.html)
- [https://github.com/ahoefling/ahoefling.github.io/blob/master/css/share.css](share.css)

The changes here should add the same share button styles I have at [http://www.andrewhoefling.com/](http://www.andrewhoefling.com/)

